### PR TITLE
Make the code more in-line with the C# version

### DIFF
--- a/src/main/kotlin/session2/Session2.kt
+++ b/src/main/kotlin/session2/Session2.kt
@@ -4,19 +4,19 @@ fun main() {
     val numbers = listOf(7, 4, 5, 6, 3, 8, 10)
 
     //Imperative
-    numbers.forEach { n -> print("${subtractTen(square(addOne(n)))} ") }
+    for (x in numbers) { println(subtractTen(square(addOne(x)))) }
 
     println("\n--------------------------")
 
     //Declarative
-    println(numbers.map { n -> addOne(n) }
-        .map { n -> square(n) }
-        .filter { n -> n < 70 }
+    numbers
+        .map(::addOne)
+        .map(::square)
+        .filter { it < 70 }
         .sorted()
         .take(2)
-        .map { n -> subtractTen(n) }
-    )
-
+        .map(::subtractTen)
+        .forEach(::println)
 }
 
 fun square(n: Int) = n * n


### PR DESCRIPTION
List of changes:
- Avoid use of higher order function "forEach" in the imperative version. (the imperative version isn't *that* imperative in all honesty)
- Pass functions to higher order functions directly, instead of wrapping them in lambdas and passing parameters explicitly (which is redundant and discouraged for composability)
- Use an implicit `it` for lambdas which take just one argument i.e. `{ n -> n < 70 }` becomes `{ it < 70 }`